### PR TITLE
Appium Android + CI fixes

### DIFF
--- a/.github/workflows/uitest.yml
+++ b/.github/workflows/uitest.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
     
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/uitest.yml
+++ b/.github/workflows/uitest.yml
@@ -1,0 +1,40 @@
+name: UITests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+    
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '10.x'
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
+      - name: UITests - Android
+        run: |
+          dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -c Release -- -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.Android/TestApp.Android.csproj --logger normal
+
+      - name: UITests - iOS
+        run: |
+          dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -c Release -- -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.iOS/TestApp.iOS.csproj --logger normal
+
+      - name: Report UITest Results
+        uses: zyborg/dotnet-tests-report@v1
+        with:
+          test_results_path: UITest/results
+          report_name: UI_Test_Results
+          report_title: UI Test Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/sample/TestApp.UITests/uitest.json
+++ b/sample/TestApp.UITests/uitest.json
@@ -4,6 +4,8 @@
         "username": "Dan",
         "password": "HelloW0r!d"
     },
+    "avdLaunchTimeout": 120000,
+    "avdReadyTimeout": 300000,
     "forceEspressoRebuild": true,
     "espressoBuildConfig": "{ \"additionalAndroidTestDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ], \"additionalAppDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ] }"
 }

--- a/sample/TestApp.UITests/uitest.json
+++ b/sample/TestApp.UITests/uitest.json
@@ -1,7 +1,8 @@
-﻿{
+{
     "appId": "com.avantipoint.testapp",
     "settings": {
         "username": "Dan",
         "password": "HelloW0r!d"
-    }
+    },
+    "espressoBuildConfig": "{ \"additionalAndroidTestDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ], \"additionalAppDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ] }"
 }

--- a/sample/TestApp.UITests/uitest.json
+++ b/sample/TestApp.UITests/uitest.json
@@ -6,6 +6,7 @@
     },
     "avdLaunchTimeout": 120000,
     "avdReadyTimeout": 300000,
+    "isHeadless": true,
     "forceEspressoRebuild": true,
     "espressoBuildConfig": "{ \"additionalAndroidTestDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ], \"additionalAppDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ] }"
 }

--- a/sample/TestApp.UITests/uitest.json
+++ b/sample/TestApp.UITests/uitest.json
@@ -4,5 +4,6 @@
         "username": "Dan",
         "password": "HelloW0r!d"
     },
+    "forceEspressoRebuild": true,
     "espressoBuildConfig": "{ \"additionalAndroidTestDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ], \"additionalAppDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ] }"
 }

--- a/sample/TestApp.UITests/uitest.json
+++ b/sample/TestApp.UITests/uitest.json
@@ -4,9 +4,12 @@
         "username": "Dan",
         "password": "HelloW0r!d"
     },
-    "avdLaunchTimeout": 120000,
-    "avdReadyTimeout": 300000,
-    "isHeadless": true,
-    "forceEspressoRebuild": true,
-    "espressoBuildConfig": "{ \"additionalAndroidTestDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ], \"additionalAppDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ] }"
+    "capabilities": {
+        "espressoBuildConfig": "{ \"additionalAndroidTestDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ], \"additionalAppDependencies\": [ \"androidx.lifecycle:lifecycle-common:2.2.0\" ] }",
+        "showGradleLog": "true",
+        "isHeadless": "true",
+        "forceEspressoRebuild": "true",
+        "avdLaunchTimeout": "120000",
+        "avdReadyTimeout": "300000"
+    }
 }

--- a/src/Xappium.Cli/Program.cs
+++ b/src/Xappium.Cli/Program.cs
@@ -102,6 +102,12 @@ namespace Xappium
 
                 ValidatePaths();
 
+                if (AppiumPort < 80 || AppiumPort > ushort.MaxValue)
+                    throw new Exception("Specified Appium Port is out of range");
+
+                if (Uri.CheckHostName(AppiumAddress) == UriHostNameType.Unknown)
+                    throw new Exception("Invalid Appium Address specified.  Must by IP Address or valid host name.");
+
                 var headBin = Path.Combine(BaseWorkingDirectory, "bin", "device");
                 var uiTestBin = Path.Combine(BaseWorkingDirectory, "bin", "uitest");
 

--- a/src/Xappium.Cli/Program.cs
+++ b/src/Xappium.Cli/Program.cs
@@ -65,6 +65,21 @@ namespace Xappium
             ShortName = "droid")]
         public int? AndroidSdk { get; }
 
+        [Option(Description = "Skips running the appium server as part of the tool and assumes another running instance",
+            LongName = "skip-appium",
+            ShortName = "sa")]
+        public bool SkipAppium { get; } = false;
+
+        [Option(Description = "Specifies the address to start appium server listening on.",
+            LongName = "appium-address",
+            ShortName = "aa")]
+        public string AppiumAddress { get; } = "127.0.0.1";
+
+        [Option(Description = "Specifies the port to start appium server listening on.",
+            LongName = "appium-port",
+            ShortName = "ap")]
+        public int AppiumPort { get; } = 4723;
+
         [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members",
             Justification = "Called by McMaster")]
         private async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
@@ -111,12 +126,24 @@ namespace Xappium
 
                 await ConfigurationGenerator.GenerateTestConfig(headBin, uiTestBin, appProject.Platform, ConfigurationPath, BaseWorkingDirectory, AndroidSdk, DisplayGeneratedConfig, cancellationToken);
 
-                if(!await Appium.Install(cancellationToken))
-                {
-                    return 0;
-                }
+                Appium.Address = AppiumAddress;
+                Appium.Port = AppiumPort;
 
-                appium = await Appium.Run(BaseWorkingDirectory).ConfigureAwait(false);
+                Logger.WriteLine($"Appium {AppiumAddress}:{AppiumPort}", LogLevel.Normal);
+
+                if (!SkipAppium)
+                {
+                    Logger.WriteLine($"Installing/running Appium...", LogLevel.Normal);
+
+                    if (!await Appium.Install(cancellationToken))
+                        return 0;
+                    
+                    appium = await Appium.Run(BaseWorkingDirectory).ConfigureAwait(false);
+                }
+                else
+                {
+                    Logger.WriteLine("Appium skipped.", LogLevel.Normal);
+                }
 
                 await DotNetTool.Test(UITestProjectPathInfo.FullName, uiTestBin, Configuration?.Trim(), Path.Combine(BaseWorkingDirectory, "results"), cancellationToken)
                     .ConfigureAwait(false);

--- a/src/Xappium.Cli/Tools/Appium.cs
+++ b/src/Xappium.Cli/Tools/Appium.cs
@@ -87,7 +87,7 @@ namespace Xappium.Tools
                     completed = true;
                 }
                 else if(line.Contains("make sure there is no other instance of this server running already") ||
-                    line.Contains("listen EADDRINUSE: address already in use 0.0.0.0:4723"))
+                    line.Contains("listen EADDRINUSE: address already in use"))
                 {
                     Logger.WriteWarning(line, defaultLog);
 

--- a/src/Xappium.Cli/Tools/Appium.cs
+++ b/src/Xappium.Cli/Tools/Appium.cs
@@ -13,13 +13,22 @@ namespace Xappium.Tools
     {
         private const string defaultLog = "appium.log";
 
+        public static string Address { get; set; } = "127.0.0.1";
+        public static int Port { get; set; } = 4723;
+
         public static string Version
         {
-            get
-            {
+            get 
+            { 
+                var address = string.Empty;
+                if (!string.IsNullOrEmpty(Address))
+                    address = $"--address {Address}";
+
+                var port = $"--port {Port}";
+                 
                 var process = new Process
                 {
-                    StartInfo = new ProcessStartInfo("appium", "-v")
+                    StartInfo = new ProcessStartInfo("appium", $"{address} {port} -v")
                     {
                         CreateNoWindow = true,
                         RedirectStandardOutput = true
@@ -69,7 +78,7 @@ namespace Xappium.Tools
 
             void HandleConsoleLine(string line)
             {
-                if (line.Contains("listener started on 0.0.0.0:4723"))
+                if (line.Contains("listener started on ") && line.Contains($":{Port}"))
                 {
                     Logger.WriteLine(line, LogLevel.Minimal, defaultLog);
 

--- a/src/Xappium.UITest/Extensions/AppiumExtensions.cs
+++ b/src/Xappium.UITest/Extensions/AppiumExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using OpenQA.Selenium.Appium;
+
+namespace Xappium.UITest.Extensions
+{
+    internal static class AppiumExtensions
+    {
+        // Espresso build config is supposed to be ok with a json string
+        // but the dotnet driver doesn't seem to work with this, and it must instead be
+        // a file path to a json file.
+        // This will check if the config option is a json string and create a temp file
+        // to pass instead if so
+        public static void FixEspressoBuildConfigOptions(this AppiumOptions options)
+        {
+            const string espressoBuildConfigCapability = "espressoBuildConfig";
+
+            var od = options.ToDictionary();
+
+            if (od.TryGetValue(espressoBuildConfigCapability, out var bc))
+            {
+                var bcStr = bc?.ToString() ?? string.Empty;
+
+                if (!string.IsNullOrEmpty(bcStr))
+                {
+                    // Check if it's a valid file and if so we don't need to do anything
+                    if (bcStr.IndexOfAny(Path.GetInvalidFileNameChars()) < 0 || !File.Exists(bcStr))
+                    {
+                        try
+                        {
+                            var bcJson = Newtonsoft.Json.Linq.JObject.Parse(bc.ToString());
+                            if (bcJson != null)
+                            {
+                                var tmpFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + "-espressoBuildConfig.json");
+                                File.WriteAllText(tmpFile, bcJson.ToString(Newtonsoft.Json.Formatting.Indented));
+
+                                // Overwrite original capability with temp file
+                                options.AddAdditionalCapability(espressoBuildConfigCapability, tmpFile);
+                            }
+                        }
+                        catch { }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Xappium.UITest/Platforms/AndroidXappiumTestEngine.cs
+++ b/src/Xappium.UITest/Platforms/AndroidXappiumTestEngine.cs
@@ -30,6 +30,7 @@ namespace Xappium.UITest.Platforms
             AddAdditionalCapability(options, MobileCapabilityType.PlatformName, "Android");
             AddAdditionalCapability(options, MobileCapabilityType.DeviceName, config.DeviceName);
             AddAdditionalCapability(options, MobileCapabilityType.AutomationName, "Espresso");
+            AddAdditionalCapability(options, "showGradleLog", true);
 
             if(!string.IsNullOrEmpty(config.UDID))
             {

--- a/src/Xappium.UITest/Platforms/AndroidXappiumTestEngine.cs
+++ b/src/Xappium.UITest/Platforms/AndroidXappiumTestEngine.cs
@@ -7,6 +7,7 @@ using OpenQA.Selenium.Appium.Android;
 using System.Drawing;
 using OpenQA.Selenium.Interactions.Internal;
 using OpenQA.Selenium.Interactions;
+using Xappium.UITest.Extensions;
 
 namespace Xappium.UITest.Platforms
 {
@@ -28,15 +29,20 @@ namespace Xappium.UITest.Platforms
 
             AddAdditionalCapability(options, MobileCapabilityType.PlatformName, "Android");
             AddAdditionalCapability(options, MobileCapabilityType.DeviceName, config.DeviceName);
-            //AddAdditionalCapability(options, "forceEspressoRebuild", true);
             AddAdditionalCapability(options, MobileCapabilityType.AutomationName, "Espresso");
-            AddAdditionalCapability(options, "enforceAppInstall", true);
 
             if(!string.IsNullOrEmpty(config.UDID))
             {
                 AddAdditionalCapability(options, MobileCapabilityType.Udid, config.UDID);
             }
 
+            // Espresso build config is supposed to be ok with a json string
+            // but the dotnet driver doesn't seem to work with this, and it must instead be
+            // a file path to a json file.
+            // This will check if the config option is a json string and create a temp file
+            // to pass instead if so
+            options.FixEspressoBuildConfigOptions();
+            
             return new AndroidDriver<AndroidElement>(config.AppiumServer, options, TimeSpan.FromSeconds(90));
         }
 


### PR DESCRIPTION
- Adds cli args for overriding appium host address/port
- Adds cli arg for skipping running appium (ie: running it manually for debug purposes or other)
- Adds a fixup for espressoBuildConfig handling of json strings (by making an intermediate file and specifying its path instead)
- Adds espressoBuildConfig configuration to the sample uitest.config file to make espresso driver work for Xamarin Android