### PR TITLE
Added View Selector strategy

### DIFF
--- a/src/Xappium.UITest/Configuration/UITestConfiguration.cs
+++ b/src/Xappium.UITest/Configuration/UITestConfiguration.cs
@@ -23,6 +23,8 @@ namespace Xappium.UITest.Configuration
 
         public string ScreenshotsPath { get; set; }
 
+        public string ViewSelectorStrategy { get; set; }
+
         public Uri AppiumServer { get; set; }
 
         public Dictionary<string, string> Capabilities { get; set; } = new Dictionary<string, string>();


### PR DESCRIPTION
By default, Appium's `MobileBy.AccessiblityId` uses the `content-desc` on android.  This presents a problem for those using this field for actual accessibility purposes.  It's not uncommon to use different values here for different builds, one set for UI Testing / automation purposes, and then toggle to the values you want screen readers to use in the app for real.  The problem is that the mere act of just setting this field on a view in android causes accessibility things to happen that wouldn't if the field wasn't set and can cause unintended behavior in screen reader contexts.

Since espresso allows for more rich view matching, we can avoid using `content-desc` altogether on android and instead use either the view's `setTag("automationId")` or better yet, `setTag(key, "automationId")` so that we are less likely to have conflicts with other parts of the code using `setTag` for other purposes.

This PR adds a config option called 'viewSelectorStrategy` which is a string and can take a couple of different values for now, which only apply to android currently:

- `tag`
- `tagWithKey:1234` where the number is the android resource identifier used for `setTag(1234, "automationId")` in the android app

If `tag` is the provided value, instead of using `content-desc` wherever you provide an `automationId` to lookup a view with, the espresso View Matcher `onView(withTagValue(is((Object)"automationId")))` will be used instead.

Similarly, if `tagWithKey:1234` is set, the view matcher ` onView(withTagKey(key, is((Object)"automationId")))` will be used.  It is important to note that the `key` in this context MUST be a valid Android Resource Identifier.  In Xamarin apps this is currently a bit troublesome since the actual resource identifier integer value is not determined until the .apk is built.  There will be support for stable resource identifiers in net6 android builds in the future.  For now it's easiest to just use the `tag` strategy.
