### PR TITLE
Commands

### DIFF
--- a/.github/workflows/uitest.yml
+++ b/.github/workflows/uitest.yml
@@ -2,11 +2,16 @@ name: UITests
 
 on:
   push:
+    branches: [ master ]
   pull_request:
 
 jobs:
 
   build:
+    strategy:
+      matrix:
+        os: [iOS, Android]
+
     runs-on: macos-latest
 
     steps:
@@ -14,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
             fetch-depth: 0
-    
+
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
@@ -25,13 +30,9 @@ jobs:
         with:
           dotnet-version: '3.1.x'
 
-      - name: UITests - Android
+      - name: UITests - ${{ matrix.os }}
         run: |
-          dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -c Release -- -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.Android/TestApp.Android.csproj --logger normal
-
-      - name: UITests - iOS
-        run: |
-          dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -c Release -- -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.iOS/TestApp.iOS.csproj --logger normal
+          dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -c Release -- test -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.${{ matrix.os }}/TestApp.${{ matrix.os }}.csproj --logger normal
 
       - name: Report UITest Results
         uses: zyborg/dotnet-tests-report@v1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
     "editor.autoIndent": "full"
   },
   "files.associations": {
-    "**/*.yml": "azure-pipelines"
+    "azure-pipelines.yml": "azure-pipelines",
+    "build/**/*.yml": "azure-pipelines"
   }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <SourceRoot Include="$(MSBuildThisFileDirectory)"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.194" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(IsPackable) ">

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The Cli tool is meant to provide an easy to use runner for your UI Tests. In ord
 It's worth noting that the tools here are designed to provide an experience that is tailored to running on an iOS Simulator or Android Emulator. These settings are not customizable.
 
 ```bash
-xappiumtest -uitest sample/TestApp.UITests/TestApp.UITests.csproj \
+xappium test -uitest sample/TestApp.UITests/TestApp.UITests.csproj \
     -app sample/TestApp.iOS/TestApp.iOS.csproj
 ```
 

--- a/Run-AndroidTests.ps1
+++ b/Run-AndroidTests.ps1
@@ -1,1 +1,1 @@
-dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -- -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.Android/TestApp.Android.csproj
+dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -- test -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.Android/TestApp.Android.csproj

--- a/build/steps/run-uitests.yml
+++ b/build/steps/run-uitests.yml
@@ -1,6 +1,13 @@
 parameters:
-  projectPath: ''
-  platform: ''
+- name: projectPath
+  type: string
+  default: ''
+- name: platform
+  type: string
+  default: ''
+- name: command
+  type: string
+  default: 'prepare'
 
 steps:
 - task: DownloadPipelineArtifact@2
@@ -23,16 +30,16 @@ steps:
     echo "Installing Xappium.Cli version $VERSION from $PIPELINE_WORKSPACE"
     touch "$DOTNET_CLI_HOME/.dotnet/$(dotnet --version).dotnetFirstUseSentinel"
     dotnet tool install -g Xappium.Cli --version $VERSION --add-source $PIPELINE_WORKSPACE
-    xappiumtest -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app ${{ parameters.projectPath }} --show-config -artifacts $ARTIFACT_DIR
+    xappium ${{ parameters.command }} -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app ${{ parameters.projectPath }} --show-config -artifacts $ARTIFACT_DIR
   displayName: Run Xappium Tests
 
-- task: PublishTestResults@2
-  condition: always()
-  inputs:
-    testRunTitle: '${{ parameters.platform }} UI Tests'
-    testResultsFiles: '$(Pipeline.Workspace)/UITests/results/*.trx'
-    failTaskOnFailedTests: true
-    testResultsFormat: VSTest
+# - task: PublishTestResults@2
+#   condition: always()
+#   inputs:
+#     testRunTitle: '${{ parameters.platform }} UI Tests'
+#     testResultsFiles: '$(Pipeline.Workspace)/UITests/results/*.trx'
+#     failTaskOnFailedTests: true
+#     testResultsFormat: VSTest
 
 - task: PublishPipelineArtifact@1
   displayName: Publish Artifacts

--- a/run-androidtests.sh
+++ b/run-androidtests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -c Release -- -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.Android/TestApp.Android.csproj --logger normal
+dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -c Release -- test -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.Android/TestApp.Android.csproj --logger normal

--- a/run-iostests.sh
+++ b/run-iostests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -c Release -- -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.iOS/TestApp.iOS.csproj --logger normal
+dotnet run --project src/Xappium.Cli/Xappium.Cli.csproj -c Release -- test -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.iOS/TestApp.iOS.csproj --logger normal

--- a/sample/TestApp.UITests/TestApp.UITests.csproj
+++ b/sample/TestApp.UITests/TestApp.UITests.csproj
@@ -9,9 +9,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Xappium.Cli/Commands/CliBase.cs
+++ b/src/Xappium.Cli/Commands/CliBase.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Threading;
+using McMaster.Extensions.CommandLineUtils;
+using Xappium.Logging;
+using Xappium.BuildSystem;
+using Xappium.Configuration;
+using System.Reactive.Disposables;
+
+namespace Xappium.Commands
+{
+    public abstract class CliBase
+    {
+        protected readonly CompositeDisposable Disposables = new CompositeDisposable();
+
+        protected FileInfo UITestProjectPathInfo => string.IsNullOrEmpty(UITestProjectPath) ? null : new FileInfo(UITestProjectPath);
+
+        protected string HeadBin
+        {
+            get
+            {
+                var headBin = Path.Combine(BaseWorkingDirectory, "bin", "device");
+                // HACK: The iOS SDK will mess up the generated app output if a Separator is not at the end of the path.
+                headBin += Path.DirectorySeparatorChar;
+                return headBin;
+            }
+        }
+
+        protected string UiTestBin
+        {
+            get
+            {
+                var uiTestBin = Path.Combine(BaseWorkingDirectory, "bin", "uitest");
+                // HACK: The iOS SDK will mess up the generated app output if a Separator is not at the end of the path.
+                uiTestBin += Path.DirectorySeparatorChar;
+                return uiTestBin;
+            }
+        }
+
+        protected FileInfo DeviceProjectPathInfo => string.IsNullOrEmpty(DeviceProjectPath) ? null : new FileInfo(DeviceProjectPath);
+
+        [Option(Description = "Specifies the csproj path of the UI Test project",
+            LongName = "uitest-project-path",
+            ShortName = "uitest")]
+        public string UITestProjectPath { get; }
+
+        [Option(Description = "Specifies the Head Project csproj path for your iOS or Android project.",
+            LongName = "app-project-path",
+            ShortName = "app")]
+        public string DeviceProjectPath { get; }
+
+        [Option(Description = "Specifies the target platform such as iOS or Android.",
+            LongName = "platform",
+            ShortName = "p")]
+        public string Platform { get; }
+
+        [Option(Description = "Specifies the Build Configuration to use on the Platform head and UITest project",
+            LongName = "configuration",
+            ShortName = "c")]
+        public string Configuration { get; } = "Release";
+
+        [Option(Description = "Specifies a UITest.json configuration path that overrides what may be in the UITest project build output directory",
+            LongName = "uitest-configuration",
+            ShortName = "ui-config")]
+        public string ConfigurationPath { get; }
+
+        [Option(Description = "Specifies the test artifact folder",
+            LongName = "artifact-staging-directory",
+            ShortName = "artifacts")]
+        public string BaseWorkingDirectory { get; } = Path.Combine(Environment.CurrentDirectory, "UITest");
+
+        [Option(Description = "Will write the generated uitest.json to the console. This should only be done if you do not have sensative settings that may be written to the console.",
+            LongName = "show-config",
+            ShortName = "show")]
+        public bool DisplayGeneratedConfig { get; }
+
+        [Option(Description = "Sets the level of logging output to the console.",
+            LongName = "logger",
+            ShortName = "l")]
+        public LogLevel LogLevel { get; } = LogLevel.Normal;
+
+        [Option(Description = "Specifies the Android SDK version to ensure is installed for the Emulator",
+            LongName = "android-sdk",
+            ShortName = "droid")]
+        public int? AndroidSdk { get; }
+
+        public async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        {
+            Logger.Level = LogLevel;
+
+            if (Directory.Exists(BaseWorkingDirectory))
+                Directory.Delete(BaseWorkingDirectory, true);
+
+            Directory.CreateDirectory(BaseWorkingDirectory);
+            Logger.SetWorkingDirectory(BaseWorkingDirectory);
+
+            try
+            {
+                Logger.WriteLine($"Build and Test artifacts will be stored at {BaseWorkingDirectory}", LogLevel.Detailed);
+
+                ValidatePaths();
+
+                await OnExecuteInternal(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteError(ex.Message);
+                return 1;
+            }
+            finally
+            {
+                Disposables.Dispose();
+            }
+
+            return Logger.HasErrors ? 1 : 0;
+        }
+
+        protected abstract Task OnExecuteInternal(CancellationToken cancellationToken);
+
+        protected void ValidatePaths()
+        {
+            if (UITestProjectPathInfo.Extension != ".csproj")
+                throw new InvalidOperationException($"The path '{UITestProjectPath}' does not specify a valid csproj");
+            else if (DeviceProjectPathInfo.Extension != ".csproj")
+                throw new InvalidOperationException($"The path '{DeviceProjectPath}' does not specify a valid csproj");
+            else if (!UITestProjectPathInfo.Exists)
+                throw new FileNotFoundException($"The specified UI Test project path does not exist: '{UITestProjectPath}'");
+            else if (!DeviceProjectPathInfo.Exists)
+                throw new FileNotFoundException($"The specified Platform head project path does not exist: '{DeviceProjectPath}'");
+        }
+
+        protected async Task PrepareProjects(CancellationToken cancellationToken)
+        {
+            Directory.CreateDirectory(HeadBin);
+            Directory.CreateDirectory(UiTestBin);
+
+            var appProject = CSProjFile.Load(DeviceProjectPathInfo, new DirectoryInfo(HeadBin), Platform);
+            if (!await appProject.IsSupported())
+                throw new PlatformNotSupportedException($"{appProject.Platform} is not supported on this machine. Please check that you have the correct build dependencies.");
+
+            await appProject.Build(Configuration, cancellationToken).ConfigureAwait(false);
+
+            var uitestProj = CSProjFile.Load(UITestProjectPathInfo, new DirectoryInfo(UiTestBin), string.Empty);
+            await uitestProj.Build(Configuration, cancellationToken).ConfigureAwait(false);
+
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            await ConfigurationGenerator.GenerateTestConfig(HeadBin, UiTestBin, appProject.Platform, ConfigurationPath, BaseWorkingDirectory, AndroidSdk, DisplayGeneratedConfig, cancellationToken);
+        }
+    }
+}

--- a/src/Xappium.Cli/Commands/PrepareCommand.cs
+++ b/src/Xappium.Cli/Commands/PrepareCommand.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Xappium.Commands
+{
+    [Command(Description = "Builds the UI Test and App and prepares the configuration for the test run")]
+    public class PrepareCommand : CliBase
+    {
+        protected override Task OnExecuteInternal(CancellationToken cancellationToken) => PrepareProjects(cancellationToken);
+    }
+}

--- a/src/Xappium.Cli/Commands/TestCommand.cs
+++ b/src/Xappium.Cli/Commands/TestCommand.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Threading;
+using McMaster.Extensions.CommandLineUtils;
+using Xappium.Logging;
+using Xappium.Tools;
+using Xappium.Utilities;
+
+namespace Xappium.Commands
+{
+    [Command(Description = "Prepares the tests, then ensures Appium is installed, starts Appium, and runs Tests.")]
+    public class TestCommand : CliBase
+    {
+        [Option(Description = "Skips running the appium server as part of the tool and assumes another running instance",
+            LongName = "skip-appium",
+            ShortName = "sa")]
+        public bool SkipAppium { get; } = false;
+
+        [Option(Description = "Specifies the address to start appium server listening on.",
+            LongName = "appium-address",
+            ShortName = "aa")]
+        public string AppiumAddress { get; } = "127.0.0.1";
+
+        [Option(Description = "Specifies the port to start appium server listening on.",
+            LongName = "appium-port",
+            ShortName = "ap")]
+        public int AppiumPort { get; } = 4723;
+
+        protected override async Task OnExecuteInternal(CancellationToken cancellationToken)
+        {
+            if (AppiumPort < 80 || AppiumPort > ushort.MaxValue)
+                throw new Exception("Specified Appium Port is out of range");
+
+            if (Uri.CheckHostName(AppiumAddress) == UriHostNameType.Unknown)
+                throw new Exception("Invalid Appium Address specified.  Must by IP Address or valid host name.");
+
+            if (!Node.IsInstalled)
+                throw new Exception("Your environment does not appear to have Node installed. This is required to run Appium");
+
+            var disposable = new DelegateDisposable(() =>
+            {
+                var binDir = Path.Combine(BaseWorkingDirectory, "bin");
+                if (Directory.Exists(binDir))
+                    Directory.Delete(binDir, true);
+            });
+            Disposables.Add(disposable);
+
+            await PrepareProjects(cancellationToken);
+
+            Appium.Address = AppiumAddress;
+            Appium.Port = AppiumPort;
+
+            Logger.WriteLine($"Appium {AppiumAddress}:{AppiumPort}", LogLevel.Normal);
+
+            if (!SkipAppium)
+            {
+                Logger.WriteLine($"Installing/running Appium...", LogLevel.Normal);
+
+                if (!await Appium.Install(cancellationToken))
+                    return;
+
+                var appium = await Appium.Run(BaseWorkingDirectory).ConfigureAwait(false);
+                Disposables.Add(appium);
+            }
+            else
+            {
+                Logger.WriteLine("Appium skipped.", LogLevel.Normal);
+            }
+
+            await DotNetTool.Test(UITestProjectPathInfo.FullName, UiTestBin, Configuration?.Trim(), Path.Combine(BaseWorkingDirectory, "results"), cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Xappium.Cli/Commands/XappiumCommand.cs
+++ b/src/Xappium.Cli/Commands/XappiumCommand.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Xappium.Commands
+{
+    [Command(
+           Name = "xappium",
+           FullName = "Xappium UITest CLI",
+           Description = "Project Home: https://github.com/xappium/xappium.uitest")]
+    [Subcommand(typeof(PrepareCommand))]
+    [Subcommand(typeof(TestCommand))]
+    public class XappiumCommand
+    {
+        private CommandLineApplication _app { get; }
+        private IConsole _console { get; }
+
+        public XappiumCommand(CommandLineApplication app, IConsole console)
+        {
+            _app = app;
+            _console = console;
+        }
+
+        private void OnExecute() => _console.WriteLine(_app.GetHelpText());
+    }
+}

--- a/src/Xappium.Cli/Program.cs
+++ b/src/Xappium.Cli/Program.cs
@@ -1,186 +1,27 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
-using McMaster.Extensions.CommandLineUtils;
-using Xappium.BuildSystem;
-using Xappium.Configuration;
-using Xappium.Logging;
-using Xappium.Tools;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xappium.Commands;
 
 namespace Xappium
 {
     internal class Program
     {
-        private FileInfo UITestProjectPathInfo => string.IsNullOrEmpty(UITestProjectPath) ? null : new FileInfo(UITestProjectPath);
+        public static Task<int> Main(string[] args) =>
+            new HostBuilder()
+            .ConfigureLogging(ConfigureLogging)
+            .ConfigureServices(ConfigureServices)
+            .RunCommandLineApplicationAsync<XappiumCommand>(args);
 
-        private FileInfo DeviceProjectPathInfo => string.IsNullOrEmpty(DeviceProjectPath) ? null : new FileInfo(DeviceProjectPath);
-
-        public static Task<int> Main(string[] args)
-            => CommandLineApplication.ExecuteAsync<Program>(args);
-
-        [Option(Description = "Specifies the csproj path of the UI Test project",
-            LongName = "uitest-project-path",
-            ShortName = "uitest")]
-        public string UITestProjectPath { get; }
-
-        [Option(Description = "Specifies the Head Project csproj path for your iOS or Android project.",
-            LongName = "app-project-path",
-            ShortName = "app")]
-        public string DeviceProjectPath { get; }
-
-        [Option(Description = "Specifies the target platform such as iOS or Android.",
-            LongName = "platform",
-            ShortName = "p")]
-        public string Platform { get; }
-
-        [Option(Description = "Specifies the Build Configuration to use on the Platform head and UITest project",
-            LongName = "configuration",
-            ShortName = "c")]
-        public string Configuration { get; } = "Release";
-
-        [Option(Description = "Specifies a UITest.json configuration path that overrides what may be in the UITest project build output directory",
-            LongName = "uitest-configuration",
-            ShortName = "ui-config")]
-        public string ConfigurationPath { get; }
-
-        [Option(Description = "Specifies the test artifact folder",
-            LongName = "artifact-staging-directory",
-            ShortName = "artifacts")]
-        public string BaseWorkingDirectory { get; } = Path.Combine(Environment.CurrentDirectory, "UITest");
-
-        [Option(Description = "Will write the generated uitest.json to the console. This should only be done if you do not have sensative settings that may be written to the console.",
-            LongName = "show-config",
-            ShortName = "show")]
-        public bool DisplayGeneratedConfig { get; }
-
-        [Option(Description = "Sets the level of logging output to the console.",
-            LongName = "logger",
-            ShortName = "l")]
-        public LogLevel LogLevel { get; } = LogLevel.Normal;
-
-        [Option(Description = "Specifies the Android SDK version to ensure is installed for the Emulator",
-            LongName = "android-sdk",
-            ShortName = "droid")]
-        public int? AndroidSdk { get; }
-
-        [Option(Description = "Skips running the appium server as part of the tool and assumes another running instance",
-            LongName = "skip-appium",
-            ShortName = "sa")]
-        public bool SkipAppium { get; } = false;
-
-        [Option(Description = "Specifies the address to start appium server listening on.",
-            LongName = "appium-address",
-            ShortName = "aa")]
-        public string AppiumAddress { get; } = "127.0.0.1";
-
-        [Option(Description = "Specifies the port to start appium server listening on.",
-            LongName = "appium-port",
-            ShortName = "ap")]
-        public int AppiumPort { get; } = 4723;
-
-        [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members",
-            Justification = "Called by McMaster")]
-        private async Task<int> OnExecuteAsync(CancellationToken cancellationToken)
+        private static void ConfigureLogging(HostBuilderContext ctx, ILoggingBuilder builder)
         {
-            IDisposable appium = null;
-            Logger.Level = LogLevel;
 
-            if (Directory.Exists(BaseWorkingDirectory))
-                Directory.Delete(BaseWorkingDirectory, true);
-
-            Directory.CreateDirectory(BaseWorkingDirectory);
-            Logger.SetWorkingDirectory(BaseWorkingDirectory);
-
-            try
-            {
-                if (!Node.IsInstalled)
-                    throw new Exception("Your environment does not appear to have Node installed. This is required to run Appium");
-
-                Logger.WriteLine($"Build and Test artifacts will be stored at {BaseWorkingDirectory}", LogLevel.Detailed);
-
-                ValidatePaths();
-
-                if (AppiumPort < 80 || AppiumPort > ushort.MaxValue)
-                    throw new Exception("Specified Appium Port is out of range");
-
-                if (Uri.CheckHostName(AppiumAddress) == UriHostNameType.Unknown)
-                    throw new Exception("Invalid Appium Address specified.  Must by IP Address or valid host name.");
-
-                var headBin = Path.Combine(BaseWorkingDirectory, "bin", "device");
-                var uiTestBin = Path.Combine(BaseWorkingDirectory, "bin", "uitest");
-
-                Directory.CreateDirectory(headBin);
-                Directory.CreateDirectory(uiTestBin);
-
-                // HACK: The iOS SDK will mess up the generated app output if a Separator is not at the end of the path.
-                headBin += Path.DirectorySeparatorChar;
-                uiTestBin += Path.DirectorySeparatorChar;
-
-                var appProject = CSProjFile.Load(DeviceProjectPathInfo, new DirectoryInfo(headBin), Platform);
-                if (!await appProject.IsSupported())
-                    throw new PlatformNotSupportedException($"{appProject.Platform} is not supported on this machine. Please check that you have the correct build dependencies.");
-
-                await appProject.Build(Configuration, cancellationToken).ConfigureAwait(false);
-
-                var uitestProj = CSProjFile.Load(UITestProjectPathInfo, new DirectoryInfo(uiTestBin), string.Empty);
-                await uitestProj.Build(Configuration, cancellationToken).ConfigureAwait(false);
-
-                if (cancellationToken.IsCancellationRequested)
-                    return 0;
-
-                await ConfigurationGenerator.GenerateTestConfig(headBin, uiTestBin, appProject.Platform, ConfigurationPath, BaseWorkingDirectory, AndroidSdk, DisplayGeneratedConfig, cancellationToken);
-
-                Appium.Address = AppiumAddress;
-                Appium.Port = AppiumPort;
-
-                Logger.WriteLine($"Appium {AppiumAddress}:{AppiumPort}", LogLevel.Normal);
-
-                if (!SkipAppium)
-                {
-                    Logger.WriteLine($"Installing/running Appium...", LogLevel.Normal);
-
-                    if (!await Appium.Install(cancellationToken))
-                        return 0;
-                    
-                    appium = await Appium.Run(BaseWorkingDirectory).ConfigureAwait(false);
-                }
-                else
-                {
-                    Logger.WriteLine("Appium skipped.", LogLevel.Normal);
-                }
-
-                await DotNetTool.Test(UITestProjectPathInfo.FullName, uiTestBin, Configuration?.Trim(), Path.Combine(BaseWorkingDirectory, "results"), cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                Logger.WriteError(ex.Message);
-                return 1;
-            }
-            finally
-            {
-                appium?.Dispose();
-
-                var binDir = Path.Combine(BaseWorkingDirectory, "bin");
-                if(Directory.Exists(binDir))
-                   Directory.Delete(binDir, true);
-            }
-
-            return Logger.HasErrors ? 1 : 0;
         }
 
-        private void ValidatePaths()
+        private static void ConfigureServices(IServiceCollection services)
         {
-            if (UITestProjectPathInfo.Extension != ".csproj")
-                throw new InvalidOperationException($"The path '{UITestProjectPath}' does not specify a valid csproj");
-            else if (DeviceProjectPathInfo.Extension != ".csproj")
-                throw new InvalidOperationException($"The path '{DeviceProjectPath}' does not specify a valid csproj");
-            else if (!UITestProjectPathInfo.Exists)
-                throw new FileNotFoundException($"The specified UI Test project path does not exist: '{UITestProjectPath}'");
-            else if (!DeviceProjectPathInfo.Exists)
-                throw new FileNotFoundException($"The specified Platform head project path does not exist: '{DeviceProjectPath}'");
+
         }
     }
 }

--- a/src/Xappium.Cli/Properties/launchSettings.json
+++ b/src/Xappium.Cli/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Xappium.Cli": {
       "commandName": "Project",
-      "commandLineArgs": "-uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.Android/TestApp.Android.csproj",
+      "commandLineArgs": "prepare -uitest sample/TestApp.UITests/TestApp.UITests.csproj -app sample/TestApp.Android/TestApp.Android.csproj",
       "workingDirectory": "C:\\repos\\OSS\\xappium.uitest"
     }
   }

--- a/src/Xappium.Cli/Utilities/DelegateDisposable.cs
+++ b/src/Xappium.Cli/Utilities/DelegateDisposable.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Xappium.Utilities
+{
+    internal class DelegateDisposable : IDisposable
+    {
+        private WeakReference<Action> _weakDelegate;
+
+        public DelegateDisposable(Action @delegate)
+        {
+            _weakDelegate = new WeakReference<Action>(@delegate);
+        }
+
+        public void Dispose()
+        {
+            if(_weakDelegate != null && _weakDelegate.TryGetTarget(out var target))
+            {
+                target?.Invoke();
+                _weakDelegate = null;
+            }
+        }
+    }
+}

--- a/src/Xappium.Cli/Xappium.Cli.csproj
+++ b/src/Xappium.Cli/Xappium.Cli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -16,6 +16,8 @@
     <PackageReference Include="AndroidXml" Version="1.1.14" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="CliWrap" Version="3.3.2" />
+    <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Xappium.Cli/Xappium.Cli.csproj
+++ b/src/Xappium.Cli/Xappium.Cli.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Xappium</RootNamespace>
     <PackAsTool>true</PackAsTool>
-    <ToolCommandName>xappiumtest</ToolCommandName>
+    <ToolCommandName>xappium</ToolCommandName>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="AndroidXml" Version="1.1.14" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="CliWrap" Version="3.3.1" />
+    <PackageReference Include="CliWrap" Version="3.3.2" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Xappium.UITest.NUnit/Xappium.UITest.NUnit.csproj
+++ b/src/Xappium.UITest.NUnit/Xappium.UITest.NUnit.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Xappium.Cli.Tests/Xappium.Cli.Tests.csproj
+++ b/tests/Xappium.Cli.Tests/Xappium.Cli.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Description

Splits CLI into sub-commands for prepare and test. Test will do everything that the prepare will do and ensure that Appium is installed and running, as well as run dotnet test.

Note that the command name has also been changed from `xappiumtest` to just `xappium`. You should now use:

```
xappium test -h

# OR

xappium prepare -h
```

### Issues or Bugs Fixed

none

### PR Checklist

- [x] Targets the master branch
- [x] Rebased on master at the time of the PR
- [x] Adheres to [Coding Styles and Contribution Guidelines](https://github.com/xappium/xappium.uitest/blob/master/.github/CONTRIBUTING.md)
- [ ] Has tests