### PR TITLE
remove compiler warning

### DIFF
--- a/src/Xappium.UITest/Providers/NUnitTestFramework.cs
+++ b/src/Xappium.UITest/Providers/NUnitTestFramework.cs
@@ -18,7 +18,7 @@ namespace Xappium.UITest.Providers
                     .FirstOrDefault(x => x.Name == "AddTestAttachment" && x.GetParameters().Length == 2);
                 addTestAttachment.Invoke(null, new[] { filePath, description });
             }
-            catch(Exception ex)
+            catch
             {
                 // Suppress errors
             }


### PR DESCRIPTION
Removed unused variable in catch block fixing issue [34](https://github.com/Xappium/xappium.uitest/issues/35)

Variable is unused. If you want to see the exception in the debugger, you can use `$exception`