### PR TITLE
unify the UIElementBase type across the known types

### DIFF
--- a/src/Xappium.UITest/Platforms/AndroidXappiumTestEngine.cs
+++ b/src/Xappium.UITest/Platforms/AndroidXappiumTestEngine.cs
@@ -46,22 +46,5 @@ namespace Xappium.UITest.Platforms
             
             return new AndroidDriver<AndroidElement>(config.AppiumServer, options, TimeSpan.FromSeconds(90));
         }
-
-        protected override IUIElement CreateUIElement(AndroidElement nativeElement) =>
-            new AndroidUIElement(nativeElement);
-
-        private class AndroidUIElement : UIElementBase<AndroidElement>
-        {
-            public AndroidUIElement(AndroidElement element)
-                : base(element)
-            {
-            }
-
-            public override ICoordinates Coordinates => _element.Coordinates;
-
-            public override Rectangle Rect => _element.Rect;
-
-            public override Point LocationOnScreenOnceScrolledIntoView => _element.LocationOnScreenOnceScrolledIntoView;
-        }
     }
 }

--- a/src/Xappium.UITest/Platforms/UIElementBase.cs
+++ b/src/Xappium.UITest/Platforms/UIElementBase.cs
@@ -1,18 +1,33 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.iOS;
 using OpenQA.Selenium.Interactions.Internal;
 
 namespace Xappium.UITest.Platforms
 {
-    internal abstract class UIElementBase<T> : IUIElement
+    internal class UIElementBase<T> : IUIElement
         where T : IWebElement
     {
         protected T _element { get; }
 
         public UIElementBase(T element)
         {
-            _element = element;
+            // If you're supporting a new IWebElement type, put a new case in each of the switch
+            // statements.
+
+            _element = element switch
+            {
+                // this is a fail fast check to get your attention if
+                // a new type gets added
+                AndroidElement _ => element,
+                IOSElement _ => element,
+                _ => throw UnknownElementType()
+            };
         }
+
+        static NotImplementedException UnknownElementType() => new NotImplementedException($"Unknown element type {typeof (T).FullName}");
 
         public bool Displayed => _element.Displayed;
 
@@ -26,10 +41,29 @@ namespace Xappium.UITest.Platforms
 
         public Size Size => _element.Size;
 
-        public abstract Rectangle Rect { get; }
 
-        public abstract ICoordinates Coordinates { get; }
+        public Rectangle Rect =>
+            _element switch
+            {
+                AndroidElement android => android.Rect,
+                IOSElement ios => ios.Rect,
+                _ => throw UnknownElementType ()
+            };
 
-        public abstract Point LocationOnScreenOnceScrolledIntoView { get; }
+        public ICoordinates Coordinates =>
+            _element switch
+            {
+                AndroidElement android => android.Coordinates,
+                IOSElement ios => ios.Coordinates,
+                _ => throw UnknownElementType()
+            };
+
+        public Point LocationOnScreenOnceScrolledIntoView =>
+            _element switch
+            {
+                AndroidElement android => android.LocationOnScreenOnceScrolledIntoView,
+                IOSElement ios => ios.LocationOnScreenOnceScrolledIntoView,
+                _ => throw UnknownElementType()
+            };
     }
 }

--- a/src/Xappium.UITest/Platforms/XappiumTestEngineBase.cs
+++ b/src/Xappium.UITest/Platforms/XappiumTestEngineBase.cs
@@ -76,7 +76,7 @@ namespace Xappium.UITest.Platforms
 
         protected abstract T CreateDriver(AppiumOptions options, UITestConfiguration config);
 
-        protected abstract IUIElement CreateUIElement(E nativeElement);
+        protected virtual IUIElement CreateUIElement(E nativeElement) => new UIElementBase<E>(nativeElement);
 
         protected WebDriverWait Wait(TimeSpan? timeout = null)
         {

--- a/src/Xappium.UITest/Platforms/iOSXappiumTestEngine.cs
+++ b/src/Xappium.UITest/Platforms/iOSXappiumTestEngine.cs
@@ -40,22 +40,5 @@ namespace Xappium.UITest.Platforms
 
             return new IOSDriver<IOSElement>(config.AppiumServer, options);
         }
-
-        protected override IUIElement CreateUIElement(IOSElement nativeElement) =>
-            new iOSUIElement(nativeElement);
-
-        private class iOSUIElement : UIElementBase<IOSElement>
-        {
-            public iOSUIElement(IOSElement element)
-                : base(element)
-            {
-            }
-
-            public override Rectangle Rect => _element.Rect;
-
-            public override ICoordinates Coordinates => _element.Coordinates;
-
-            public override Point LocationOnScreenOnceScrolledIntoView => _element.LocationOnScreenOnceScrolledIntoView;
-        }
     }
 }


### PR DESCRIPTION
Since we are only (currently) supporting 2 driver types and the accessors are identical but without a common interface or base class,  put everything into the base class.